### PR TITLE
feat: add option to upload to dataframe, docs + tests update

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ Available keyword arguments for `get` method:
 - `options` (optional)
 - `callback` (optional)
 
+You can also specify the resulting outputs form, whether it's `json` or a Panda's `dataframe`, by passing the `output_format` param as follows: 
+
+```python
+df = namara.get('5885fce0-92c4-4acb-960f-82ce5a0a4650', 'en-1', options, output_format='dataframe')
+print(df.head()) #prints first 5 rows of the resulting table 
+```
+
+It is important to note that it currently only accepts the options `"json"` or `"dataframe"`, and it defaults to `"json"`. 
+
 ### Options
 
 All [Namara data options](https://namara.io/#/api) are supported.

--- a/namara/__init__.py
+++ b/namara/__init__.py
@@ -36,8 +36,14 @@ class Namara:
         def response_hook(response, *args, **kwargs):
             if self.debug: 
                 logging.debug('REQUEST URL: ' + response.url)
-            response.data = self.__extract_datasets(response.json()) if response.ok else response.json()
-            callback(response)
+            response.data = response.json()
+            if output_format is 'json': 
+                callback(response.data)
+            elif output_format is 'dataframe': 
+                df = pd.DataFrame(response.data)
+                callback(df)
+            else: 
+                raise ValueError('`output_format` param must be "json" or "dataframe"')
 
         self.__session.get(url, params=options, headers=self.headers, hooks={
             'response': response_hook
@@ -71,9 +77,15 @@ class Namara:
             if self.debug: 
                 logging.debug('REQUEST URL: ' + response.url)
             response.data = response.json()
-            callback(response)
+            if output_format is 'json': 
+                callback(response.data)
+            elif output_format is 'dataframe': 
+                df = pd.DataFrame(response.data)
+                callback(df)
+            else: 
+                raise ValueError('`output_format` param must be "json" or "dataframe"')
 
-        self.__session.get(url, params=options, headers=self.headers, hooks={
+        res = self.__session.get(url, params=options, headers=self.headers, hooks={
             'response': response_hook,
         })
 

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,13 @@ except ImportError:
 setup(
     name='namara',
     packages=['namara'],
-    version='0.2.0',
+    version='0.2.1',
     description='The official Python client for the Namara data collaboration platform',
     author='ThinkData Works',
     author_email='info@namara.io',
     license='Apache-2.0',
     url='https://github.com/namara-io/namara-python',
     keywords=['namara','open data','api','canada','us','government','independent'],
-    install_requires=['requests-futures==0.9.9'],
+    install_requires=['requests-futures==0.9.9', 'pandas', 'logging'],
     classifiers=[]
 )

--- a/test_namara.py
+++ b/test_namara.py
@@ -10,19 +10,19 @@ class TestNamara(TestCase):
         self.dataset = '18b854e3-66bd-4a00-afba-8eabfc54f524'
         self.version = 'en-2'
 
-    def test_base_path(self):
-        path = self.subject.get_base_path(self.dataset, self.version)
-        self.assertTrue(path == 'https://api.namara.io/v0/data_sets/18b854e3-66bd-4a00-afba-8eabfc54f524/data/en-2')
+    def test_get_url(self): 
+        path = self.subject.get_url('/organizations/{0}/projects/{1}/data_sets'.format('organization', 'project'))
+        self.assertTrue(path == 'https://api.namara.io/v0/organizations/organization/projects/project/data_sets')
 
-    def test_path(self):
-        path = self.subject.get_path(self.dataset, self.version)
-        self.assertTrue(path == 'https://api.namara.io/v0/data_sets/18b854e3-66bd-4a00-afba-8eabfc54f524/data/en-2?api_key=myapikey')
+    def test_is_aggregation(self): 
+        options = {'limit': 10, 'operation': 'avg(column_1)'} 
+        self.assertTrue(self.subject.is_aggregation(options))
 
     def test_get_where_field_value_greater_than_1200(self):
         self.subject.get = Mock(return_value=[{u'mnr_region': u'NORTHWEST', u'facility_name': u'RESOLUTE FP CANADA INC.', u'facility_code': 1201, u'location': u'FORT FRANCES', u'facility_type': u'PULP'}, {u'mnr_region': u'NORTHWEST', u'facility_name': u'MANITOU FOREST PRODUCTS LTD.', u'facility_code': 1221, u'location': u'EMO', u'facility_type': u'SAWMILL'}, {u'mnr_region': u'NORTHWEST', u'facility_name': u'531322 ONTARIO LTD. O/A NICKEL LAKE LUMBER', u'facility_code': 1232, u'location': u'FORT FRANCES', u'facility_type': u'SAWMILL'}, {u'mnr_region': u'NORTHWEST', u'facility_name': u'AINSWORTH GP LTD.', u'facility_code': 1240, u'location': u'BARWICK', u'facility_type': u'COMPOSITE'}, {u'mnr_region': u'NORTHWEST', u'facility_name': u'RESOLUTE FP CANADA INC.', u'facility_code': 1301, u'location': u'IGNACE', u'facility_type': u'SAWMILL'}, {u'mnr_region': u'NORTHWEST', u'facility_name': u'E.&G. CUSTOM SAWING LTD.', u'facility_code': 1410, u'location': u'KENORA', u'facility_type': u'SAWMILL'}, {u'mnr_region': u'NORTHWEST', u'facility_name': u'WEYERHAEUSER COMPANY LTD.', u'facility_code': 1422, u'location': u'KENORA', u'facility_type': u'COMPOSITE'}])
-        response = self.subject.get(self.dataset, self.version, options={'where': 'facility_code > 1000'})
-        for i in range(0, len(response)):
-            if response[i].get('facility_code') <= 1200:
+        response = self.subject.get(self.dataset, self.version, options={'where': 'facility_code > 1200'})
+        for res in response:
+            if res.get('facility_code') <= 1200:
                 self.assertTrue(False)
         self.assertTrue(True)
 
@@ -30,3 +30,6 @@ class TestNamara(TestCase):
         self.subject.get = Mock(return_value={u'result': 129})
         response = self.subject.get(self.dataset, self.version, options={'operation': 'count(*)'})
         self.assertTrue(response.get('result') == 129)
+
+    def test_valid_output_format(self): 
+        self.assertRaises(ValueError, self.subject.get, self.dataset, self.version, output_format='invalid-format')

--- a/test_namara.py
+++ b/test_namara.py
@@ -2,6 +2,9 @@ from unittest import TestCase
 from mock import Mock
 from namara import Namara
 
+import pandas as pd 
+
+
 class TestNamara(TestCase):
     subject = None
 
@@ -33,3 +36,13 @@ class TestNamara(TestCase):
 
     def test_valid_output_format(self): 
         self.assertRaises(ValueError, self.subject.get, self.dataset, self.version, output_format='invalid-format')
+
+    def test_valid_json_output(self): 
+        self.subject.get = Mock(return_value=[{u'mnr_region': u'NORTHWEST', u'facility_name': u'RESOLUTE FP CANADA INC.', u'facility_code': 1201, u'location': u'FORT FRANCES', u'facility_type': u'PULP'}, {u'mnr_region': u'NORTHWEST', u'facility_name': u'MANITOU FOREST PRODUCTS LTD.', u'facility_code': 1221, u'location': u'EMO', u'facility_type': u'SAWMILL'}, {u'mnr_region': u'NORTHWEST', u'facility_name': u'531322 ONTARIO LTD. O/A NICKEL LAKE LUMBER', u'facility_code': 1232, u'location': u'FORT FRANCES', u'facility_type': u'SAWMILL'}, {u'mnr_region': u'NORTHWEST', u'facility_name': u'AINSWORTH GP LTD.', u'facility_code': 1240, u'location': u'BARWICK', u'facility_type': u'COMPOSITE'}, {u'mnr_region': u'NORTHWEST', u'facility_name': u'RESOLUTE FP CANADA INC.', u'facility_code': 1301, u'location': u'IGNACE', u'facility_type': u'SAWMILL'}, {u'mnr_region': u'NORTHWEST', u'facility_name': u'E.&G. CUSTOM SAWING LTD.', u'facility_code': 1410, u'location': u'KENORA', u'facility_type': u'SAWMILL'}, {u'mnr_region': u'NORTHWEST', u'facility_name': u'WEYERHAEUSER COMPANY LTD.', u'facility_code': 1422, u'location': u'KENORA', u'facility_type': u'COMPOSITE'}])
+        response = self.subject.get(self.dataset, self.version, options={'operation': 'count(*)'}, output_format='json')
+        self.assertTrue(isinstance(response, list))
+
+    def test_valid_dataframe_ouput(self): 
+        self.subject.get = Mock(return_value=pd.DataFrame(data={'col1': [1, 2], 'col2': [3, 4]}))
+        response = self.subject.get(self.dataset, self.version, options={'operation': 'count(*)'}, output_format='dataframe')
+        self.assertTrue(isinstance(response, pd.DataFrame))


### PR DESCRIPTION
Hey! Great package, loving the product and the flexibility that is offered via the API. 

This is regarding issue #3 

I made this rough PR to introduce an option to specify the output format (for now, either `json` (default) or `dataframe` (Panda's df)). I approached this by just adding an extra param to the `get` methods (I thought it would increase the flexibility of adding more output format options), but if you'd prefer this to be in a stand-alone function let me know. I also fixed some tests and added another, plus updated the docs. 

I was also wondering if you would like to refactor this API to use `asyncio` and `aiohttp` instead of `requests_futures` since those seem to be natively supported in Python3 and `requests_futures` isn't maintained, let me know if this is also something that's worthwhile pursuing. 

