### PR TITLE
Remove builtin modules from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(
     license='Apache-2.0',
     url='https://github.com/namara-io/namara-python',
     keywords=['namara','open data','api','canada','us','government','independent'],
-    install_requires=['requests-futures==0.9.9', 'pandas', 'logging', 'time', 'requests', 'shutil'],
+    install_requires=['requests-futures==0.9.9', 'pandas', 'requests'],
     classifiers=[]
 )


### PR DESCRIPTION
The modules logging, time, and shutil are builtin and shouldn't be
listed here.